### PR TITLE
Fix font rendering

### DIFF
--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -20,10 +20,10 @@
     <style>
       img.preview {
         min-width: 100%;
-        image-rendering: crisp-edges;
+        image-rendering: -webkit-optimize-contrast;
         image-rendering: -moz-crisp-edges;
         image-rendering: -o-crisp-edges;
-        image-rendering: -webkit-optimize-contrast;
+        image-rendering: pixelated;
         -ms-interpolation-mode: nearest-neighbor;
       }
     </style>


### PR DESCRIPTION
Closes #1. This commit re-orders the `image-rendering` values and changes the bottom-most one to `pixelated`, making this ideally render properly on (according to caniuse) 99.8% of browsers. Since rules that appear later in a stylesheet override previous ones if they have the same specificity (this should mean that the image-rendering rules will be applied from top to bottom), this should be able to be used to help with compatibility. I believe that, at least in my instance, most browsers will skip CSS properties that are invalid or that they don't recognize, so having the topmost rule be the most compatibility-friendly one and the bottom-most (minus the IE rule) be the plain `pixelated` rule should mean that the rules are applied appropriately per platform. I've not been able to test this, so if there are any discrepancies let me know.